### PR TITLE
fix rollup tips  aboat 'rxjs/add/operator/first'

### DIFF
--- a/tools/gulp/tasks/components.ts
+++ b/tools/gulp/tasks/components.ts
@@ -78,6 +78,7 @@ task(':build:components:rollup', [':build:components:inline'], () => {
     'rxjs/add/operator/share': 'Rx.Observable.prototype',
     'rxjs/add/operator/finally': 'Rx.Observable.prototype',
     'rxjs/add/operator/catch': 'Rx.Observable.prototype',
+    'rxjs/add/operator/first': 'Rx.Observable.prototype',
     'rxjs/Observable': 'Rx'
   };
 


### PR DESCRIPTION
Treating 'rxjs/add/operator/first' as external dependency
No name was provided for external module 'rxjs/add/operator/first' in options.globals – guessing 'rxjs_add_operator_first'
